### PR TITLE
CI: disable Yarn hardened mode for all but one job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,9 +6,15 @@ on:
   pull_request:
   merge_group:
 
+env:
+  YARN_ENABLE_HARDENED_MODE: "0"
+
 jobs:
   yarn-duplicates:
     runs-on: ubuntu-latest
+    env:
+      # This one runs with YARN_ENABLE_HARDENED_MODE=1, all the others run with 0
+      YARN_ENABLE_HARDENED_MODE: "1"
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 18.x


### PR DESCRIPTION
ref. https://yarnpkg.com/features/security#:~:text=If%20your%20CI%20pipeline%20runs%20multiple%20jobs%2C%20we%20recommend%20disabling%20the%20hardened%20mode%20in%20all%20but%20one%20of%20them%20so%20as%20to%20limit%20the%20performance%20impact.