### PR TITLE
[BDGR-173] Add new automated release workflow

### DIFF
--- a/.github/steps/setup-playwright/action.yml
+++ b/.github/steps/setup-playwright/action.yml
@@ -1,0 +1,35 @@
+name: Set Up Playwright
+description: Sets up Playwright
+inputs:
+  working-directory:
+    description: Where to run
+    required: false
+runs:
+  using: composite
+  steps:
+    # Adapted from https://playwrightsolutions.com/playwright-github-action-to-cache-the-browser-binaries/
+    - name: Get installed Playwright version
+      id: playwright-version
+      run: echo version=$(yarn info --json @playwright/test | jq -r '.children.Version') >> $GITHUB_OUTPUT
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash
+
+    - name: Cache playwright binaries
+      uses: actions/cache@v4
+      id: playwright-cache
+      with:
+        path: |
+          ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
+    - name: Install Playwright Browsers
+      run: yarn playwright install --with-deps
+      working-directory: ${{ inputs.working-directory }}
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
+      shell: bash
+
+    - name: Install Playwright OS dependencies
+      run: npx playwright install-deps
+      working-directory: ${{ inputs.working-directory }}
+      if: steps.playwright-cache.outputs.cache-hit == 'true'
+      shell: bash

--- a/.github/workflows/build_canary.yml
+++ b/.github/workflows/build_canary.yml
@@ -1,0 +1,15 @@
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build:
+    uses: ./.github/workflows/build_shared.yml
+    with:
+      ref: ${{ github.ref }}
+      tag: ${{ github.ref_name }}
+      strip_rc: true

--- a/.github/workflows/build_shared.yml
+++ b/.github/workflows/build_shared.yml
@@ -8,7 +8,10 @@ on:
       tag:
         type: string
         required: true
-        description: Docker tag to push
+        description: Version to build, also the docker tag
+      strip_rc:
+        type: boolean
+        description: Strip -rc suffix from version number
 
 permissions:
   contents: read
@@ -34,7 +37,17 @@ jobs:
 
       - run: yarn install --immutable
 
-      - run: "yarn package"
+      - name: Set version
+        shell: pwsh
+        run: |
+          $pkg = Get-Content ./desktop/package.json | ConvertFrom-Json
+          $pkg.version = "${{inputs.tag }}" -replace "^v", ""
+          if ("${{ inputs.strip_rc }}" -eq "true") {
+            $pkg.version = $pkg.version -replace "-rc.*", ""
+          }
+          $pkg | ConvertTo-Json -Depth 32 | Set-Content ./desktop/package.json
+
+      - run: "yarn package --win --publish never"
         working-directory: ./desktop
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -67,6 +80,15 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set version
+        run: |
+          set -x
+          version=$(echo '${{ inputs.tag }}' | sed 's/^v//')
+          if [[ '${{ inputs.strip_rc }}' == 'true' ]]; then
+            version=$(echo $version | sed 's/-rc.*//')
+          fi
+          cat package.json | jq '.version = "'$version'"' | tee package.json
+        working-directory: ./jobrunner
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -74,8 +96,7 @@ jobs:
           images: ghcr.io/ystv/badger/server
           flavor: latest=true
           tags: |
-            type=semver,pattern={{version}},enable=${{ github.event_name == 'workflow_dispatch' }}
-            type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_call' }}
+            type=raw,value=${{ inputs.tag }}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -101,6 +122,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set version
+        run: |
+          version=$(echo '${{ inputs.tag }}' | sed 's/^v//')
+          if [[ '${{ inputs.strip_rc }}' == 'true' ]]; then
+            version=$(echo $version | sed 's/-rc.*//')
+          fi
+          cat package.json | jq '.version = "'$version'"' | tee package.json
       - name: Docker metadata
         id: jr_meta
         uses: docker/metadata-action@v5
@@ -108,8 +136,7 @@ jobs:
           images: ghcr.io/ystv/badger/jobrunner
           flavor: latest=true
           tags: |
-            type=semver,pattern={{version}},enable=${{ github.event_name == 'workflow_dispatch' }}
-            type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_call' }}
+            type=raw,value=${{ inputs.tag }}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/build_shared.yml
+++ b/.github/workflows/build_shared.yml
@@ -100,6 +100,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
+          context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -141,6 +142,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
+          context: .
           push: true
           tags: ${{ steps.jr_meta.outputs.tags }}
           labels: ${{ steps.jr_meta.outputs.labels }}

--- a/.github/workflows/build_shared.yml
+++ b/.github/workflows/build_shared.yml
@@ -87,8 +87,8 @@ jobs:
           if [[ '${{ inputs.strip_rc }}' == 'true' ]]; then
             version=$(echo $version | sed 's/-rc.*//')
           fi
-          sed -i "s/0.0.0/$version/g" ./server/package.json
-        working-directory: ./jobrunner
+          sed -i "s/0.0.0/$version/g" package.json
+        working-directory: ./server
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -128,7 +128,8 @@ jobs:
           if [[ '${{ inputs.strip_rc }}' == 'true' ]]; then
             version=$(echo $version | sed 's/-rc.*//')
           fi
-          sed -i "s/0.0.0/$version/g" ./jobrunner/package.json
+          sed -i "s/0.0.0/$version/g" package.json
+        working-directory: ./jobrunner
       - name: Docker metadata
         id: jr_meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/build_shared.yml
+++ b/.github/workflows/build_shared.yml
@@ -87,7 +87,7 @@ jobs:
           if [[ '${{ inputs.strip_rc }}' == 'true' ]]; then
             version=$(echo $version | sed 's/-rc.*//')
           fi
-          cat package.json | jq '.version = "'$version'"' | tee package.json
+          sed -i "s/0.0.0/$version/g" ./server/package.json
         working-directory: ./jobrunner
       - name: Docker metadata
         id: meta
@@ -128,7 +128,7 @@ jobs:
           if [[ '${{ inputs.strip_rc }}' == 'true' ]]; then
             version=$(echo $version | sed 's/-rc.*//')
           fi
-          cat package.json | jq '.version = "'$version'"' | tee package.json
+          sed -i "s/0.0.0/$version/g" ./jobrunner/package.json
       - name: Docker metadata
         id: jr_meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,7 +217,6 @@ jobs:
             const lin = new LinearClient({
               accessToken: "${{ secrets.LINEAR_ACCESS_TOKEN }}"
             });
-            await lin.updateIssue({
-              issueId: "${{ needs.linear.outputs.issue_id }}",
+            await lin.updateIssue("${{ needs.linear.outputs.issue_id }}", {
               stateId: "${{ vars.LINEAR_DONE_STATE_ID }}",
             });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,16 +3,15 @@ on:
     tags:
       - "*-rc*"
 
-permissions:
-  contents: write
-  packages: write
+permissions: write-all
 
 jobs:
   build:
     uses: ./.github/workflows/build_shared.yml
     with:
-      ref: ${{ github.event.before }}
-      tag: ${{ github.event.ref }}
+      ref: ${{ github.ref }}
+      tag: ${{ github.ref_name }}
+      strip_rc: true
 
   test-e2e-server:
     needs: [build]
@@ -23,83 +22,154 @@ jobs:
       DATABASE_URL: postgres://root:postgres@localhost:5432/badger_test
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18.x
-          cache: "yarn"
-          cache-dependency-path: "yarn.lock"
+      # - name: Use Node.js 18.x
+      #   uses: actions/setup-node@v4
+      #   with:
+      #     node-version: 18.x
+      #     cache: "yarn"
+      #     cache-dependency-path: "yarn.lock"
 
-      - name: Set ref in docker-compose
-        run: sed -i "s/__RC_REF__/${{ github.event.ref }}/g" docker-compose-rc-test.yml
+      # - name: Set ref in docker-compose
+      #   run: sed -i "s/__RC_REF__/${{ github.ref_name }}/g" docker-compose-rc-test.yml
 
-      - name: Start services
-        run: docker compose up -d -f docker-compose.yml -f docker-compose-rc-test.yml
+      # - name: Start services
+      #   run: docker compose -f docker-compose.yml -f docker-compose-rc-test.yml up -d
 
-      # Adapted from https://playwrightsolutions.com/playwright-github-action-to-cache-the-browser-binaries/
-      - name: Get installed Playwright version
-        id: playwright-version
-        run: echo version=$(yarn info --json @playwright/test | jq -r '.children.Version') >> $GITHUB_OUTPUT
-        working-directory: ./server
+      # - run: yarn install --immutable --inline-builds
 
-      - name: Cache playwright binaries
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: |
-            ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+      # - uses: ./.github/steps/setup-playwright
+      #   with:
+      #     working-directory: ./server
 
-      - name: Install Playwright Browsers
-        run: yarn playwright install --with-deps
-        working-directory: ./server
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+      # - name: Migrate database
+      #   run: |
+      #     yarn prisma:migrateProd
 
-      - name: Install Playwright OS dependencies
-        run: npx playwright install-deps
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
+      # - name: Retart services
+      #   run: |
+      #     docker compose -f docker-compose.yml -f docker-compose-rc-test.yml restart server jobrunner
 
-      - name: Migrate database
-        run: yarn prisma:migrateProd
+      # - name: Run Playwright tests
+      #   run: yarn ${{ runner.debug && 'test:e2e:debug' || 'test:e2e' }}
+      #   working-directory: ./server
+      #   env:
+      #     PLAYWRIGHT_HTML_REPORT: ${{ github.workspace }}/server/playwright-report
 
-      - name: Run Playwright tests
-        run: yarn ${{ runner.debug && 'test:e2e:debug' || 'test:e2e' }}
-        working-directory: ./server
-        env:
-          PLAYWRIGHT_HTML_REPORT: ${{ github.workspace }}/server/playwright-report
+      # - uses: actions/upload-artifact@v3
+      #   if: failure()
+      #   with:
+      #     name: playwright-report-server
+      #     path: ./server/playwright-report/
+      #     retention-days: 30
 
-      - uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: playwright-report-server
-          path: ./server/playwright-report/
-          retention-days: 30
+  test-desktop:
+    runs-on: windows-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v4
+      # - name: Use Node.js 18.x
+      #   uses: actions/setup-node@v4
+      #   with:
+      #     node-version: 18.x
+      #     cache: "yarn"
+      #     cache-dependency-path: "yarn.lock"
+      # - name: Download Desktop build
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: badger-desktop-windows
+      # - name: Install Badger
+      #   run: |
+      #     $version = "${{ github.ref_name }}" -replace "^v", "" -replace "-rc.*", ""
+      #     Start-Process -FilePath "Badger Desktop-$version.exe" -ArgumentList "/S","/D=${{ runner.temp }}\badger" -Wait
+      #   shell: pwsh
+      # - run: yarn install --immutable --inline-builds
+      # - name: Run tests
+      #   run: yarn test:e2e --project=standalone
+      #   working-directory: ./desktop
+      #   env:
+      #     TEST_APPLICATION_PATH: ${{ runner.temp }}\badger\Badger Desktop.exe
 
-  release:
-    needs: [test-e2e-server, build]
-    environment: release
+  linear:
+    needs: [test-e2e-server, test-desktop]
     runs-on: ubuntu-latest
+    outputs:
+      issue_id: ${{ steps.issue.outputs.issue_id }}
     steps:
       - name: Determine version number
-        run: echo "VERSION=$(echo '${{ github.event.ref }}' | sed 's/^refs\/tags\///' | sed 's/-rc.*//')" >> $GITHUB_ENV
+        run: echo "VERSION=$(echo '${{ github.ref_name }}' | sed 's/-rc.*//')" >> $GITHUB_ENV
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20.x"
+      - run: npm install @linear/sdk
+      - name: Create Linear release ticket
+        id: issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { LinearClient } = require('@linear/sdk');
+            const lin = new LinearClient({
+              accessToken: "${{ secrets.LINEAR_ACCESS_TOKEN }}"
+            });
+            const issueCreate = await lin.createIssue({
+              teamId: "${{ vars.LINEAR_TEAM_ID }}",
+              templateId: "${{ vars.LINEAR_RELEASE_ISSUE_TEMPLATE_ID }}",
+              stateId: "${{ vars.LINEAR_TODO_STATE_ID }}",
+              title: `Release ${{ github.ref_name }}`,
+            });
+            if (!issueCreate.success) {
+              throw new Error(`Failed to create issue`);
+            }
+            const issue = await issueCreate.issue;
+
+            await lin.createComment({
+              issueId: issue.id,
+              body: `Artifacts:
+                Server Docker image: \`ghcr.io/ystv/badger/server:${{ github.ref_name }}\`    
+                Jobrunner Docker Image: \`ghcr.io/ystv/badger/jobrunner:${{ github.ref_name }}\`    
+                Desktop Windows installer: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+                Once testing is complete, please approve [this workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+              `.replace(/^\s*/gm, ''),
+            });
+
+            core.summary.addHeading('Linear issue');
+            core.summary.addLink(issue.identifier, issue.url);
+            core.setOutput('issue_id', issue.id);
+
+  release:
+    needs: [test-e2e-server, test-desktop, linear]
+    environment: release
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Determine version number
+        run: echo "VERSION=$(echo '${{ github.ref_name }}' | sed 's/-rc.*//')" >> $GITHUB_ENV
       - name: Download Desktop build
         uses: actions/download-artifact@v4
         with:
+          pattern: badger-desktop-*
           path: artifacts
-      - name: Pull Docker images
-        run: |
-          docker pull ghcr.io/ystv/badger/server:${{ github.event.ref }}
-          docker pull ghcr.io/ystv/badger/jobrunner:${{ github.event.ref }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Re-tag and push Docker images
-        run:
-          docker tag ghcr.io/ystv/badger/server:${{ github.event.ref }} ghcr.io/ystv/badger/server:$VERSION
-          docker tag ghcr.io/ystv/badger/jobrunner:${{ github.event.ref }} ghcr.io/ystv/badger/jobrunner:$VERSION
-          docker push ghcr.io/ystv/badger/server:$VERSION
-          docker push ghcr.io/ystv/badger/jobrunner:$VERSION
+        run: |
+          for img in server jobrunner; do
+            docker pull ghcr.io/ystv/badger/$img:${{ github.ref_name }}
+            docker tag ghcr.io/ystv/badger/$img:${{ github.ref_name }} ghcr.io/ystv/badger/$img:$VERSION
+            docker push ghcr.io/ystv/badger/$img:$VERSION
+            docker tag ghcr.io/ystv/badger/$img:${{ github.ref_name }} ghcr.io/ystv/badger/$img:latest
+            docker push ghcr.io/ystv/badger/$img:latest
+          done
+        shell: bash
       - name: Create GitHub release
         uses: actions/github-script@v7
         id: release
         with:
+          github-token: ${{ secrets.GH_RELEASE_PAT }}
           script: |
             const release = await github.rest.repos.createRelease({
               owner: context.repo.owner,
@@ -109,21 +179,39 @@ jobs:
               name: process.env.VERSION,
               draft: true,
               generate_release_notes: true,
-              make_latest: true
+              prerelease: false
             });
             core.setOutput('id', release.data.id)
-            core.setOutput('upload_url', release.data.upload_url)
             core.setOutput('tag_name', release.data.tag_name)
       - name: Upload artifacts
         run: |
           find artifacts -type f -exec gh release upload ${{ steps.release.outputs.tag_name }} {} \;
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
       - name: Publish release
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             await github.rest.repos.updateRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              release_id: ${{ steps.release.outputs.id }},
+              release_id: "${{ steps.release.outputs.id }}",
               draft: false
             })
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20.x"
+      - run: npm install @linear/sdk
+      - name: Close Linear issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { LinearClient } = require('@linear/sdk');
+            const lin = new LinearClient({
+              accessToken: "${{ secrets.LINEAR_ACCESS_TOKEN }}"
+            });
+            await lin.updateIssue({
+              issueId: "${{ needs.linear.outputs.issue_id }}",
+              stateId: "${{ vars.LINEAR_DONE_STATE_ID }}",
+            });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,8 +191,7 @@ jobs:
             core.setOutput('tag_name', release.data.tag_name)
       - name: Upload artifacts
         run: |
-          find artifacts -type f -exec echo {} +
-          find artifacts -type f -exec gh release upload --clobber -R ystv/badger ${{ steps.release.outputs.tag_name }} {} +
+          find artifacts -type f -not -name '*.yml' -not -name '*.yaml' -print0 | xargs -0 -I{} gh release -R ystv/badger upload --clobber ${{ steps.release.outputs.tag_name }} '{}'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
       - name: Publish release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,7 @@ jobs:
             core.setOutput('tag_name', release.data.tag_name)
       - name: Upload artifacts
         run: |
-          find artifacts -type f -exec gh release upload -R ystv/badger ${{ steps.release.outputs.tag_name }} {} +
+          find artifacts -type f -exec gh release upload --clobber -R ystv/badger ${{ steps.release.outputs.tag_name }} {} +
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
       - name: Publish release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
                 Jobrunner Docker Image: \`ghcr.io/ystv/badger/jobrunner:${{ github.ref_name }}\`    
                 Desktop Windows installer: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-                Once testing is complete, please approve [this workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+                Once testing is complete, please approve [this workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) to publish the release.
               `.replace(/^\s*/gm, ''),
             });
 
@@ -179,13 +179,19 @@ jobs:
               name: process.env.VERSION,
               draft: true,
               generate_release_notes: true,
-              prerelease: false
+              prerelease: false,
+              body: [
+                '## Docker images',
+                `- Server: \`ghcr.io/ystv/badger/server:${process.env.VERSION}\``,
+                `- Jobrunner: \`ghcr.io/ystv/badger/jobrunner:${process.env.VERSION}\``,
+                ''
+              ].join('\n'),
             });
             core.setOutput('id', release.data.id)
             core.setOutput('tag_name', release.data.tag_name)
       - name: Upload artifacts
         run: |
-          find artifacts -type f -exec gh release upload ${{ steps.release.outputs.tag_name }} {} \;
+          gh release upload ${{ steps.release.outputs.tag_name }} artifacts/*
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
       - name: Publish release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,7 @@ jobs:
             core.setOutput('tag_name', release.data.tag_name)
       - name: Upload artifacts
         run: |
-          gh release upload ${{ steps.release.outputs.tag_name }} artifacts/*
+          gh release upload -R ystv/badger ${{ steps.release.outputs.tag_name }} artifacts/*
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
       - name: Publish release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,72 +22,72 @@ jobs:
       DATABASE_URL: postgres://root:postgres@localhost:5432/badger_test
     steps:
       - uses: actions/checkout@v4
-      # - name: Use Node.js 18.x
-      #   uses: actions/setup-node@v4
-      #   with:
-      #     node-version: 18.x
-      #     cache: "yarn"
-      #     cache-dependency-path: "yarn.lock"
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: "yarn"
+          cache-dependency-path: "yarn.lock"
 
-      # - name: Set ref in docker-compose
-      #   run: sed -i "s/__RC_REF__/${{ github.ref_name }}/g" docker-compose-rc-test.yml
+      - name: Set ref in docker-compose
+        run: sed -i "s/__RC_REF__/${{ github.ref_name }}/g" docker-compose-rc-test.yml
 
-      # - name: Start services
-      #   run: docker compose -f docker-compose.yml -f docker-compose-rc-test.yml up -d
+      - name: Start services
+        run: docker compose -f docker-compose.yml -f docker-compose-rc-test.yml up -d
 
-      # - run: yarn install --immutable --inline-builds
+      - run: yarn install --immutable --inline-builds
 
-      # - uses: ./.github/steps/setup-playwright
-      #   with:
-      #     working-directory: ./server
+      - uses: ./.github/steps/setup-playwright
+        with:
+          working-directory: ./server
 
-      # - name: Migrate database
-      #   run: |
-      #     yarn prisma:migrateProd
+      - name: Migrate database
+        run: |
+          yarn prisma:migrateProd
 
-      # - name: Retart services
-      #   run: |
-      #     docker compose -f docker-compose.yml -f docker-compose-rc-test.yml restart server jobrunner
+      - name: Retart services
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose-rc-test.yml restart server jobrunner
 
-      # - name: Run Playwright tests
-      #   run: yarn ${{ runner.debug && 'test:e2e:debug' || 'test:e2e' }}
-      #   working-directory: ./server
-      #   env:
-      #     PLAYWRIGHT_HTML_REPORT: ${{ github.workspace }}/server/playwright-report
+      - name: Run Playwright tests
+        run: yarn ${{ runner.debug && 'test:e2e:debug' || 'test:e2e' }}
+        working-directory: ./server
+        env:
+          PLAYWRIGHT_HTML_REPORT: ${{ github.workspace }}/server/playwright-report
 
-      # - uses: actions/upload-artifact@v3
-      #   if: failure()
-      #   with:
-      #     name: playwright-report-server
-      #     path: ./server/playwright-report/
-      #     retention-days: 30
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: playwright-report-server
+          path: ./server/playwright-report/
+          retention-days: 30
 
   test-desktop:
     runs-on: windows-latest
     needs: [build]
     steps:
       - uses: actions/checkout@v4
-      # - name: Use Node.js 18.x
-      #   uses: actions/setup-node@v4
-      #   with:
-      #     node-version: 18.x
-      #     cache: "yarn"
-      #     cache-dependency-path: "yarn.lock"
-      # - name: Download Desktop build
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: badger-desktop-windows
-      # - name: Install Badger
-      #   run: |
-      #     $version = "${{ github.ref_name }}" -replace "^v", "" -replace "-rc.*", ""
-      #     Start-Process -FilePath "Badger Desktop-$version.exe" -ArgumentList "/S","/D=${{ runner.temp }}\badger" -Wait
-      #   shell: pwsh
-      # - run: yarn install --immutable --inline-builds
-      # - name: Run tests
-      #   run: yarn test:e2e --project=standalone
-      #   working-directory: ./desktop
-      #   env:
-      #     TEST_APPLICATION_PATH: ${{ runner.temp }}\badger\Badger Desktop.exe
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: "yarn"
+          cache-dependency-path: "yarn.lock"
+      - name: Download Desktop build
+        uses: actions/download-artifact@v4
+        with:
+          name: badger-desktop-windows
+      - name: Install Badger
+        run: |
+          $version = "${{ github.ref_name }}" -replace "^v", "" -replace "-rc.*", ""
+          Start-Process -FilePath "Badger Desktop-$version.exe" -ArgumentList "/S","/D=${{ runner.temp }}\badger" -Wait
+        shell: pwsh
+      - run: yarn install --immutable --inline-builds
+      - name: Run tests
+        run: yarn test:e2e --project=standalone
+        working-directory: ./desktop
+        env:
+          TEST_APPLICATION_PATH: ${{ runner.temp }}\badger\Badger Desktop.exe
 
   linear:
     needs: [test-e2e-server, test-desktop]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,7 @@ jobs:
             core.setOutput('tag_name', release.data.tag_name)
       - name: Upload artifacts
         run: |
-          gh release upload -R ystv/badger ${{ steps.release.outputs.tag_name }} artifacts/*
+          find artifacts -type f -exec gh release upload -R ystv/badger ${{ steps.release.outputs.tag_name }} {} +
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
       - name: Publish release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,6 +191,7 @@ jobs:
             core.setOutput('tag_name', release.data.tag_name)
       - name: Upload artifacts
         run: |
+          find artifacts -type f -exec echo {} +
           find artifacts -type f -exec gh release upload --clobber -R ystv/badger ${{ steps.release.outputs.tag_name }} {} +
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,28 +162,9 @@ jobs:
           cp ../utility/prisma/schema.prisma .
         working-directory: ./jobrunner
 
-      # Adapted from https://playwrightsolutions.com/playwright-github-action-to-cache-the-browser-binaries/
-      - name: Get installed Playwright version
-        id: playwright-version
-        run: echo version=$(yarn info --json @playwright/test | jq -r '.children.Version') >> $GITHUB_OUTPUT
-        working-directory: ./server
-
-      - name: Cache playwright binaries
-        uses: actions/cache@v4
-        id: playwright-cache
+      - uses: ./.github/steps/setup-playwright
         with:
-          path: |
-            ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
-
-      - name: Install Playwright Browsers
-        run: yarn playwright install --with-deps
-        working-directory: ./server
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-
-      - name: Install Playwright OS dependencies
-        run: npx playwright install-deps
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
+          working-directory: ./server
 
       - name: Migrate database
         run: yarn prisma:migrateProd

--- a/desktop/e2e/standalone/base.ts
+++ b/desktop/e2e/standalone/base.ts
@@ -35,8 +35,13 @@ const test = base.extend<{
   },
 
   app: async ({ scenario, testMediaPath }, use, testInfo) => {
+    // Allow running tests on a built / installed app
+    const electronPath = process.env.TEST_APPLICATION_PATH;
     const app = await electron.launch({
-      args: ["--enable-logging", "out/main/index.js"],
+      args: electronPath
+        ? ["--enable-logging"]
+        : ["--enable-logging", "out/main/index.js"],
+      executablePath: electronPath,
       env: {
         ...process.env,
         NODE_ENV: "test",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "badger-desktop",
   "productName": "Badger Desktop",
-  "version": "1.0.3-canary.8",
+  "version": "0.0.0",
   "description": "My Electron application description",
   "main": "./out/main/index.js",
   "scripts": {

--- a/desktop/src/main/media/downloadFile.ts
+++ b/desktop/src/main/media/downloadFile.ts
@@ -65,7 +65,7 @@ const CurlDownloader: Downloader = async function CurlDownloader(
 ) {
   invariant(curlPath, "no curl path");
   logger.info("Using curl downloader");
-  const args = ["-f", "--compressed", "-o", outputPath, url];
+  const args = ["-f", "--compressed", "--location", "-o", outputPath, url];
   logger.info(`Curl command: ${curlPath} ${args.join(" ")}`);
   const proc = spawn(curlPath, args);
   if (progressCB) {

--- a/docker-compose-rc-test.yml
+++ b/docker-compose-rc-test.yml
@@ -1,3 +1,4 @@
+# Used by the release GitHub Actions workflow.
 version: "3"
 services:
   server:
@@ -14,7 +15,7 @@ services:
       AWS_SECRET_ACCESS_KEY: "rootroot"
       AWS_REGION: "us-east-1"
       STORAGE_BUCKET: "badger"
-      API_SHARED_SECRET: "password"
+      API_SHARED_SECRET: "aaa"
       PUBLIC_URL: "http://localhost:3000"
       JWT_SIGNING_KEY: "somesecret"
       NODE_ENV: "test"
@@ -24,4 +25,6 @@ services:
     image: ghcr.io/ystv/badger/jobrunner:__RC_REF__
     platform: linux/amd64
     command: ["--watch", "--healthPort", "28342"] # matching server/playwright.config.ts
+    ports:
+      - "28342:28342"
     environment: *badger_env

--- a/jobrunner/package.json
+++ b/jobrunner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badger-jobrunner",
-  "version": "1.0.3-canary.8",
+  "version": "0.0.0",
   "packageManager": "yarn@4.4.1",
   "type": "commonjs",
   "scripts": {

--- a/server/app/layout.tsx
+++ b/server/app/layout.tsx
@@ -9,7 +9,7 @@ import { checkSession } from "@/lib/auth";
 import { UserProvider } from "@/components/CurrentUser";
 import Script from "next/script";
 import { FeatureFlagsProvider } from "@/components/FeatureFlags";
-import { getTusEndpoint } from "@/lib/tus";
+import { getPublicTusEndpoint } from "@/lib/tus";
 import { UploadProgress } from "@/components/Uploader";
 
 export const metadata: Metadata = {
@@ -32,7 +32,7 @@ export default async function RootLayout({
           {`window.ENVIRONMENT = ${JSON.stringify(process.env.ENVIRONMENT)};`}
         </Script>
         <Script id="tus-endpoint" strategy="beforeInteractive">
-          {`window.TUS_ENDPOINT = ${JSON.stringify(getTusEndpoint())};`}
+          {`window.TUS_ENDPOINT = ${JSON.stringify(getPublicTusEndpoint())};`}
         </Script>
       </head>
       <body>

--- a/server/app/shows/[show_id]/rundown/[rundown_id]/page.tsx
+++ b/server/app/shows/[show_id]/rundown/[rundown_id]/page.tsx
@@ -4,7 +4,7 @@ import { RundownItems } from "./RundownItems";
 import RundownAssets from "./RundownAssets";
 import Link from "next/link";
 import { TusEndpointProvider } from "@/components/MediaUpload";
-import { getTusEndpoint } from "@/lib/tus";
+import { getPublicTusEndpoint } from "@/lib/tus";
 import { Suspense, cache } from "react";
 import { Button } from "@badger/components/button";
 import { MetadataTargetType } from "@badger/prisma/client";
@@ -176,7 +176,7 @@ export default async function RundownPage(props: {
 
           <h2 className="text-xl font-bold">{rundown.name}</h2>
         </div>
-        <TusEndpointProvider value={getTusEndpoint()}>
+        <TusEndpointProvider value={getPublicTusEndpoint()}>
           <Suspense fallback={<div>Loading...</div>}>
             <RundownMetadata showID={rundown.showId} rundownID={rundown.id} />
           </Suspense>

--- a/server/e2e/lib.ts
+++ b/server/e2e/lib.ts
@@ -4,7 +4,7 @@ import {
   PutObjectCommand,
   S3Client,
 } from "@aws-sdk/client-s3";
-import { Page, expect, test as base, Request } from "@playwright/test";
+import { Page, expect, test as base } from "@playwright/test";
 import {
   CreateTRPCProxyClient,
   createTRPCProxyClient,

--- a/server/e2e/metadata.spec.ts
+++ b/server/e2e/metadata.spec.ts
@@ -1,5 +1,10 @@
-import { expect } from "@playwright/test";
-import { test, getAPIClient, fileToDataTransfer, createShow } from "./lib";
+import {
+  test,
+  expect,
+  getAPIClient,
+  fileToDataTransfer,
+  createShow,
+} from "./lib";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 

--- a/server/e2e/showItems.spec.ts
+++ b/server/e2e/showItems.spec.ts
@@ -1,7 +1,12 @@
-import { expect } from "@playwright/test";
 import { readFileSync } from "fs";
 import * as path from "node:path";
-import { test, fileToDataTransfer, createShow, createMedia } from "./lib";
+import {
+  test,
+  expect,
+  fileToDataTransfer,
+  createShow,
+  createMedia,
+} from "./lib";
 
 test("add, reorder, remove items", async ({ showPage }) => {
   await expect

--- a/server/e2e/shows.spec.ts
+++ b/server/e2e/shows.spec.ts
@@ -1,5 +1,4 @@
-import { test, expect } from "@playwright/test";
-import { createShowAPI } from "./lib";
+import { test, expect, createShowAPI } from "./lib";
 
 test("loads", async ({ page }) => {
   await page.goto("/");

--- a/server/microserver/scenarios/default/default.spec.ts
+++ b/server/microserver/scenarios/default/default.spec.ts
@@ -9,6 +9,7 @@ import {
   ExtendedMediaModelWithDownloadURL,
 } from "@badger/prisma/utilityTypes";
 import { z } from "zod";
+import { omit } from "lodash";
 
 test("microserver/scenarios/default", async ({ page, micro, live }) => {
   await createShow(page, "Test Show");
@@ -19,7 +20,11 @@ test("microserver/scenarios/default", async ({ page, micro, live }) => {
   // assertions. Playwright isn't built for that, and assumes each test
   // is isolated, so we do it all in one test.
 
-  expect.soft(await micro.ping.query()).toMatchObject(await live.ping.query());
+  // Version is determined at build time
+  const dropVersion = (o: object) => omit(o, "version");
+  expect
+    .soft(dropVersion(await micro.ping.query()))
+    .toMatchObject(dropVersion(await live.ping.query()));
 
   expect
     .soft(cleanShows(await micro.shows.listUpcoming.query()))

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badger-server",
-  "version": "1.0.3-canary.8",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
(Pretend you never saw the literally 35 commits I squashed into this one...)

New release process:

1. Push a tag matching `vx.x.x-rc.x`
2. Actions builds Server/Jobrunner docker images and Windows Desktop builds
3. Runs tests (THIS IS THE COOL BIT - it runs the E2E server/desktop tests *on* the build it just made)
4. Automatically files a Linear ticket with a testing checklist (using a template on the team) and waits for approval
  * Currently I'm the only approver but this can easily be changed
5. When approved, pushes the docker images to `:latest` and creates a GH release without the `-rc` suffix

Fixes [BDGR-173](https://linear.app/ystv/issue/BDGR-173/validationqa-process-for-releases)