### PR TITLE
Limit processing task output display in UI to 75 characters

### DIFF
--- a/server/components/MediaState.tsx
+++ b/server/components/MediaState.tsx
@@ -142,7 +142,14 @@ function MediaProcessingState({
                   {task.description}
                   {task.additionalInfo.length > 0 && (
                     <>
-                      &nbsp;<small>({task.additionalInfo})</small>
+                      &nbsp;
+                      <small>
+                        (
+                        {task.additionalInfo.substring(
+                          Math.max(0, task.additionalInfo.length - 75),
+                        ) + (task.additionalInfo.length > 75 ? "..." : "")}
+                        )
+                      </small>
                     </>
                   )}
                 </li>

--- a/server/components/MediaState.tsx
+++ b/server/components/MediaState.tsx
@@ -145,9 +145,10 @@ function MediaProcessingState({
                       &nbsp;
                       <small>
                         (
-                        {task.additionalInfo.substring(
-                          Math.max(0, task.additionalInfo.length - 75),
-                        ) + (task.additionalInfo.length > 75 ? "..." : "")}
+                        {(task.additionalInfo.length > 75 ? "..." : "") +
+                          task.additionalInfo.substring(
+                            Math.max(0, task.additionalInfo.length - 75),
+                          )}
                         )
                       </small>
                     </>


### PR DESCRIPTION
ffmpeg logs can be spammy and only have the useful info at the end, so trim it. Does not affect serverside logging.