### PR TITLE
Pin tusd version used in dev/tests to same used at YSTV

### DIFF
--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -42,7 +42,7 @@ services:
       "
 
   tusd:
-    image: tusproject/tusd:latest
+    image: tusproject/tusd:sha-b4ffdf4
     depends_on:
       - minio
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       "
 
   tusd:
-    image: tusproject/tusd:latest
+    image: tusproject/tusd:sha-b4ffdf4
     depends_on:
       - minio
     ports:


### PR DESCRIPTION
Some tests have mysteriously started failing and I suspect it's a tus update (egg on my face for using `latest`...), so pin it to what we use in prod.